### PR TITLE
feature/change-client-id-type: Changed client id to varchar, nuked migrations

### DIFF
--- a/access_control/migrations/versions/e8d15433bc60_.py
+++ b/access_control/migrations/versions/e8d15433bc60_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 49b80a81af08
+Revision ID: e8d15433bc60
 Revises: 
-Create Date: 2018-01-22 10:20:41.514350
+Create Date: 2018-03-05 15:39:06.461420
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = '49b80a81af08'
+revision = 'e8d15433bc60'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -30,7 +30,7 @@ def upgrade():
     )
     op.create_index(op.f('ix_domain_name'), 'domain', ['name'], unique=True)
     op.create_table('invitation',
-    sa.Column('id', postgresql.UUID(), nullable=False),
+    sa.Column('id', access_control.models.GUID(), nullable=False),
     sa.Column('first_name', sa.Text(), nullable=True),
     sa.Column('last_name', sa.Text(), nullable=True),
     sa.Column('email', sa.VARCHAR(length=100), nullable=True),
@@ -96,7 +96,7 @@ def upgrade():
     sa.Column('name', sa.VARCHAR(length=30), nullable=True),
     sa.Column('domain_id', sa.Integer(), nullable=True),
     sa.Column('description', sa.Text(), nullable=True),
-    sa.Column('client_id', sa.Integer(), nullable=True),
+    sa.Column('client_id', sa.VARCHAR(length=256), nullable=True),
     sa.Column('is_active', sa.Boolean(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=True),
     sa.Column('updated_at', sa.DateTime(), nullable=True),

--- a/access_control/migrations/versions/e8d15433bc60_.py
+++ b/access_control/migrations/versions/e8d15433bc60_.py
@@ -8,6 +8,7 @@ Create Date: 2018-03-05 15:39:06.461420
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+import access_control
 
 # revision identifiers, used by Alembic.
 revision = 'e8d15433bc60'

--- a/access_control/migrations/versions/e8d15433bc60_.py
+++ b/access_control/migrations/versions/e8d15433bc60_.py
@@ -97,7 +97,7 @@ def upgrade():
     sa.Column('name', sa.VARCHAR(length=30), nullable=True),
     sa.Column('domain_id', sa.Integer(), nullable=True),
     sa.Column('description', sa.Text(), nullable=True),
-    sa.Column('client_id', sa.VARCHAR(length=256), nullable=True),
+    sa.Column('client_id', sa.VARCHAR(length=255), nullable=True),
     sa.Column('is_active', sa.Boolean(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=True),
     sa.Column('updated_at', sa.DateTime(), nullable=True),

--- a/access_control/models.py
+++ b/access_control/models.py
@@ -155,7 +155,7 @@ class Site(DB.Model):
     name = DB.Column(DB.VARCHAR(30), unique=True, index=True)
     domain_id = DB.Column(DB.Integer, DB.ForeignKey("domain.id"), index=True)
     description = DB.Column(DB.Text)
-    client_id = DB.Column(DB.Integer, unique=True, index=True)
+    client_id = DB.Column(DB.VARCHAR(256), unique=True, index=True)
     is_active = DB.Column(DB.Boolean, default=True)
     created_at = DB.Column(DB.DateTime, default=utcnow())
     updated_at = DB.Column(

--- a/access_control/models.py
+++ b/access_control/models.py
@@ -155,7 +155,7 @@ class Site(DB.Model):
     name = DB.Column(DB.VARCHAR(30), unique=True, index=True)
     domain_id = DB.Column(DB.Integer, DB.ForeignKey("domain.id"), index=True)
     description = DB.Column(DB.Text)
-    client_id = DB.Column(DB.VARCHAR(256), unique=True, index=True)
+    client_id = DB.Column(DB.VARCHAR(255), unique=True, index=True)
     is_active = DB.Column(DB.Boolean, default=True)
     created_at = DB.Column(DB.DateTime, default=utcnow())
     updated_at = DB.Column(

--- a/swagger/access_control.yml
+++ b/swagger/access_control.yml
@@ -196,7 +196,7 @@ definitions:
         maxLength: 30
       client_id:
         type: string
-        maxLength: 256
+        maxLength: 255
       domain_id:
         type: integer
       description:
@@ -227,7 +227,7 @@ definitions:
         maxLength: 30
       client_id:
         type: string
-        maxLength: 256
+        maxLength: 255
       domain_id:
         type: integer
       description:
@@ -243,7 +243,7 @@ definitions:
     properties:
       client_id:
         type: string
-        maxLength: 256
+        maxLength: 255
       domain_id:
         type: integer
       name:

--- a/swagger/access_control.yml
+++ b/swagger/access_control.yml
@@ -196,7 +196,7 @@ definitions:
         maxLength: 30
       client_id:
         type: string
-        format: uuid
+        maxLength: 256
       domain_id:
         type: integer
       description:
@@ -227,7 +227,7 @@ definitions:
         maxLength: 30
       client_id:
         type: string
-        format: uuid
+        maxLength: 256
       domain_id:
         type: integer
       description:
@@ -243,7 +243,7 @@ definitions:
     properties:
       client_id:
         type: string
-        format: uuid
+        maxLength: 256
       domain_id:
         type: integer
       name:

--- a/swagger_server/models/site.py
+++ b/swagger_server/models/site.py
@@ -143,6 +143,8 @@ class Site(Model):
         :param client_id: The client_id of this Site.
         :type client_id: str
         """
+        if client_id is not None and len(client_id) > 255:
+            raise ValueError("Invalid value for `client_id`, length must be less than or equal to `255`")  # noqa: E501
 
         self._client_id = client_id
 

--- a/swagger_server/models/site_create.py
+++ b/swagger_server/models/site_create.py
@@ -105,6 +105,8 @@ class SiteCreate(Model):
         :param client_id: The client_id of this SiteCreate.
         :type client_id: str
         """
+        if client_id is not None and len(client_id) > 255:
+            raise ValueError("Invalid value for `client_id`, length must be less than or equal to `255`")  # noqa: E501
 
         self._client_id = client_id
 

--- a/swagger_server/models/site_update.py
+++ b/swagger_server/models/site_update.py
@@ -80,6 +80,8 @@ class SiteUpdate(Model):
         :param client_id: The client_id of this SiteUpdate.
         :type client_id: str
         """
+        if client_id is not None and len(client_id) > 255:
+            raise ValueError("Invalid value for `client_id`, length must be less than or equal to `255`")  # noqa: E501
 
         self._client_id = client_id
 

--- a/swagger_server/swagger/swagger.yaml
+++ b/swagger_server/swagger/swagger.yaml
@@ -1870,7 +1870,7 @@ definitions:
         maxLength: 30
       client_id:
         type: "string"
-        format: "uuid"
+        maxLength: 255
       domain_id:
         type: "integer"
       description:
@@ -1893,7 +1893,7 @@ definitions:
       description: "description"
       created_at: "2000-01-23T04:56:07.000+00:00"
       id: 0
-      client_id: "046b6c7f-0b8a-43b9-b35d-6489e6daee91"
+      client_id: "client_id"
   site_create:
     type: "object"
     required:
@@ -1905,7 +1905,7 @@ definitions:
         maxLength: 30
       client_id:
         type: "string"
-        format: "uuid"
+        maxLength: 255
       domain_id:
         type: "integer"
       description:
@@ -1917,7 +1917,7 @@ definitions:
     properties:
       client_id:
         type: "string"
-        format: "uuid"
+        maxLength: 255
       domain_id:
         type: "integer"
       name:


### PR DESCRIPTION
Swagger spec had client_id as uuid string, so it only needed a maxlength.

Updated SQLAlchemy model and re created migrations.

