### PR TITLE
Governance team members need to be able to see the roles...

### DIFF
--- a/access_control/fixtures/load_role_resource_permissions.py
+++ b/access_control/fixtures/load_role_resource_permissions.py
@@ -32,10 +32,14 @@ ROLE_RESOURCE_PERMISSIONS = {
         ("urn:ge:identity_provider:user", "read"),
         ("urn:ge:identity_provider:user", "update"),
         ("urn:ge:identity_provider:user", "delete"),
+        ("urn:ge:access_control:usersiterole", "read"),
+        ("urn:ge:access_control:userdomainrole", "read"),
         ("urn:ge:management_portal:users:export", "create"),
     ],
     "governance_viewer": [
         ("urn:ge:identity_provider:user", "read"),
+        ("urn:ge:access_control:usersiterole", "read"),
+        ("urn:ge:access_control:userdomainrole", "read"),
         ("urn:ge:management_portal:users:export", "create"),
     ],
     "data_admin": [


### PR DESCRIPTION
...a user has on sites and domains.

When merged these changes can be effected by running `python seed_data.py` on the access control container.