### PR TITLE
Added some additional permissions for governance team members. As wel…

### DIFF
--- a/access_control/fixtures/load_role_resource_permissions.py
+++ b/access_control/fixtures/load_role_resource_permissions.py
@@ -5,13 +5,21 @@ https://praekelt.atlassian.net/wiki/spaces/GEM/pages/55574535/Global+Management+
 ROLE_RESOURCE_PERMISSIONS = {
     # Do not define any permissions for the "tech_admin" role
     "role_delegator": [
+        # View the domains and sites and roles
+        ("urn:ge:access_control:role", "read"),
+        ("urn:ge:access_control:site", "read"),
+        ("urn:ge:access_control:siterole", "read"),
+        ("urn:ge:access_control:usersiterole", "read"),
+        ("urn:ge:access_control:domain", "read"),
+        ("urn:ge:access_control:domainrole", "read"),
+        ("urn:ge:access_control:userdomainrole", "read"),
         # Assign/remove roles to/from users
         ("urn:ge:access_control:userdomainrole", "create"),
         ("urn:ge:access_control:userdomainrole", "read"),
         ("urn:ge:access_control:userdomainrole", "delete"),
         ("urn:ge:access_control:usersiterole", "create"),
         ("urn:ge:access_control:usersiterole", "read"),
-        ("urn:ge:access_control:userdomainrole", "delete"),
+        ("urn:ge:access_control:usersiterole", "delete"),
         # Search for users
         ("urn:ge:identity_provider:user", "read"),
         # Invite a user
@@ -32,13 +40,23 @@ ROLE_RESOURCE_PERMISSIONS = {
         ("urn:ge:identity_provider:user", "read"),
         ("urn:ge:identity_provider:user", "update"),
         ("urn:ge:identity_provider:user", "delete"),
+        ("urn:ge:access_control:role", "read"),
+        ("urn:ge:access_control:site", "read"),
+        ("urn:ge:access_control:siterole", "read"),
         ("urn:ge:access_control:usersiterole", "read"),
+        ("urn:ge:access_control:domain", "read"),
+        ("urn:ge:access_control:domainrole", "read"),
         ("urn:ge:access_control:userdomainrole", "read"),
         ("urn:ge:management_portal:users:export", "create"),
     ],
     "governance_viewer": [
         ("urn:ge:identity_provider:user", "read"),
+        ("urn:ge:access_control:role", "read"),
+        ("urn:ge:access_control:site", "read"),
+        ("urn:ge:access_control:siterole", "read"),
         ("urn:ge:access_control:usersiterole", "read"),
+        ("urn:ge:access_control:domain", "read"),
+        ("urn:ge:access_control:domainrole", "read"),
         ("urn:ge:access_control:userdomainrole", "read"),
         ("urn:ge:management_portal:users:export", "create"),
     ],


### PR DESCRIPTION
*Background*: Being able to read the userdomainroles and usersiteroles requires the role to be able to see information about domains and roles.

*What was done*: Added some additional permissions for governance team members. As well as some on the role delagator which were noticed.