### PR TITLE
Populate fields that should not be allowed to be NULL

### DIFF
--- a/swagger_server/controllers/access_control_controller.py
+++ b/swagger_server/controllers/access_control_controller.py
@@ -61,16 +61,16 @@ SQL_REDEEM_INVITATION = """
 
 BEGIN;
 
-INSERT INTO user_domain_role (user_id, domain_id, role_id)
-SELECT :user_id, domain_id, role_id
+INSERT INTO user_domain_role (user_id, domain_id, role_id, created_at, updated_at)
+SELECT :user_id, domain_id, role_id, NOW(), NOW()
   FROM invitation_domain_role
  WHERE invitation_id = :invitation_id;
 
 DELETE FROM invitation_domain_role
  WHERE invitation_id = :invitation_id;
 
-INSERT INTO user_site_role (user_id, site_id, role_id)
-SELECT :user_id, site_id, role_id
+INSERT INTO user_site_role (user_id, site_id, role_id, created_at, updated_at)
+SELECT :user_id, site_id, role_id, NOW(), NOW()
   FROM invitation_site_role
  WHERE invitation_id = :invitation_id;
 


### PR DESCRIPTION
I missed the fact that `created_at` and `updated_at` were not set. Those columns are supposed to have `NOT NULL` constraints, which was not added. This fix just makes sure that we populate those columns. There is another ticket to add the constraints at a later stage.