### PR TITLE
Added new migration with not null field changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ services:
   - docker
   - postgresql
 
+addons:
+  postresql: "9.6"
+
 install:
   - pip install -r requirements.txt -r test-requirements.txt
   - pip install coveralls

--- a/access_control/migrations/versions/08dce55f9b1f_.py
+++ b/access_control/migrations/versions/08dce55f9b1f_.py
@@ -1,0 +1,394 @@
+"""empty message
+
+Revision ID: 08dce55f9b1f
+Revises: a5e2677741fd
+Create Date: 2018-08-08 13:27:44.810620
+
+"""
+import datetime
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Session
+
+from access_control.models import Domain, Invitation, \
+    Permission, Resource, Role, Site
+
+# revision identifiers, used by Alembic.
+revision = '08dce55f9b1f'
+down_revision = 'a5e2677741fd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    now = "'{}'".format(datetime.datetime.now().isoformat())
+    empty_uuid = "'{}'".format("00000000-0000-0000-0000-000000000000")
+    empty_name = "'No one'"
+    empty_description = "'No Description'"
+    # EDITED MIGRATION: Updates on existing fields where null are populated.
+    sql = "UPDATE {table} SET {column} = {value} WHERE {column} IS NULL;"
+    session.execute(sql.format(table="domain", column="created_at", value=now))
+    session.execute(sql.format(table="domain", column="description", value=empty_description))
+    domains = session.query(Domain).filter(Domain.name.is_(None)).all()
+    for domain in domains:
+        domain.name = str(uuid.uuid4())[:30]
+    session.execute(sql.format(table="domain", column="updated_at", value=now))
+    session.execute(sql.format(table="domain_role", column="created_at", value=now))
+    session.execute(sql.format(table="domain_role", column="grant_implicitly", value="false"))
+    session.execute(sql.format(table="domain_role", column="updated_at", value=now))
+    session.execute(sql.format(table="invitation", column="created_at", value=now))
+    invitations = session.query(Invitation).filter(Invitation.email.is_(None)).all()
+    for invitation in invitations:
+        invitation.email = "placeholder@{uuid}.com".format(uuid=str(uuid.uuid4()))
+    session.execute(sql.format(table="invitation", column="first_name", value=empty_name))
+    session.execute(sql.format(table="invitation", column="invitor_id", value=empty_uuid))
+    session.execute(sql.format(table="invitation", column="last_name", value=empty_name))
+    session.execute(sql.format(table="invitation", column="organisation_id", value="-1"))
+    session.execute(sql.format(table="invitation", column="updated_at", value=now))
+    session.execute(sql.format(table="invitation_domain_role", column="created_at", value=now))
+    session.execute(sql.format(table="invitation_domain_role", column="updated_at", value=now))
+    session.execute(sql.format(table="invitation_site_role", column="created_at", value=now))
+    session.execute(sql.format(table="invitation_site_role", column="updated_at", value=now))
+    session.execute(sql.format(table="permission", column="created_at", value=now))
+    session.execute(sql.format(table="permission", column="description", value=empty_description))
+    permissions = session.query(Permission).filter(Permission.name.is_(None)).all()
+    for permission in permissions:
+        permission.name = str(uuid.uuid4())[:30]
+    session.execute(sql.format(table="permission", column="updated_at", value=now))
+    session.execute(sql.format(table="resource", column="created_at", value=now))
+    session.execute(sql.format(table="resource", column="description", value=empty_description))
+    session.execute(sql.format(table="resource", column="updated_at", value=now))
+    resources = session.query(Resource).filter(Resource.urn.is_(None)).all()
+    for resource in resources:
+        resource.urn = str(uuid.uuid4())
+    session.execute(sql.format(table="role", column="created_at", value=now))
+    session.execute(sql.format(table="role", column="description", value=empty_description))
+    roles = session.query(Role).filter(Role.label.is_(None)).all()
+    for role in roles:
+        role.label = str(uuid.uuid4())[:30]
+    session.execute(sql.format(table="role", column="requires_2fa", value="false"))
+    session.execute(sql.format(table="role", column="updated_at", value=now))
+    session.execute(sql.format(table="role_resource_permission", column="created_at", value=now))
+    session.execute(sql.format(table="role_resource_permission", column="updated_at", value=now))
+    session.execute(sql.format(table="site", column="created_at", value=now))
+    session.execute(sql.format(table="site", column="description", value=empty_description))
+    # All sites without a domain_id should be set to the parent domain and can be manually corrected.
+    sites = session.query(Site).filter(Site.name.is_(None)).all()
+    if sites:
+        parent_domain = session.query(Domain).filter(Domain.parent_id.is_(None)).first()
+        if not parent_domain:
+            parent_domain = session.query(Domain).first()
+            # If there are sites and no domains, make a dud domain, to be removed when the
+            if not parent_domain:
+                parent_domain = Domain(
+                    name="Placeholder",
+                    description="A placeholder for sites that had no domain."
+                                "Please move the sites under this domain then remove this domain."
+                )
+                session.add(parent_domain)
+                session.commit()
+        domain_id = parent_domain.id
+        session.execute(sql.format(
+            table="site", column="domain_id", value="{domain_id}".format(domain_id=domain_id)))
+        session.execute(sql.format(table="site", column="is_active", value="false"))
+
+        for site in sites:
+            site.name = str(uuid.uuid4())[:30]
+        session.execute(sql.format(table="site", column="updated_at", value=now))
+    session.execute(sql.format(table="site_role", column="created_at", value=now))
+    session.execute(sql.format(table="site_role", column="grant_implicitly", value="false"))
+    session.execute(sql.format(table="site_role", column="updated_at", value=now))
+    session.execute(sql.format(table="user_domain_role", column="created_at", value=now))
+    session.execute(sql.format(table="user_domain_role", column="updated_at", value=now))
+    session.execute(sql.format(table="user_site_role", column="created_at", value=now))
+    session.execute(sql.format(table="user_site_role", column="updated_at", value=now))
+
+    session.commit()
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.alter_column('domain', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('domain', 'description',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('domain', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=False)
+    op.alter_column('domain', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('domain_role', 'grant_implicitly',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+    op.alter_column('domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation', 'email',
+               existing_type=sa.VARCHAR(length=100),
+               nullable=False)
+    op.alter_column('invitation', 'first_name',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('invitation', 'invitor_id',
+               existing_type=postgresql.UUID(),
+               nullable=False)
+    op.alter_column('invitation', 'last_name',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('invitation', 'organisation_id',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+    op.alter_column('invitation', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation_domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation_domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation_site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('invitation_site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('permission', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('permission', 'description',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('permission', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=False)
+    op.alter_column('permission', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('resource', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('resource', 'description',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('resource', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('resource', 'urn',
+               existing_type=sa.VARCHAR(length=100),
+               nullable=False)
+    op.alter_column('role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('role', 'description',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('role', 'label',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=False)
+    op.alter_column('role', 'requires_2fa',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+    op.alter_column('role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('role_resource_permission', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('role_resource_permission', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('site', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('site', 'description',
+               existing_type=sa.TEXT(),
+               nullable=False)
+    op.alter_column('site', 'domain_id',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+    op.alter_column('site', 'is_active',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+    op.alter_column('site', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=False)
+    op.alter_column('site', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('site_role', 'grant_implicitly',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+    op.alter_column('site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('user_domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('user_domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('user_site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('user_site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.alter_column('user_site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('user_site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('user_domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('user_domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('site_role', 'grant_implicitly',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    op.alter_column('site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('site', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('site', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=True)
+    op.alter_column('site', 'is_active',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    op.alter_column('site', 'domain_id',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('site', 'description',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('site', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('role_resource_permission', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('role_resource_permission', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('role', 'requires_2fa',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    op.alter_column('role', 'label',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=True)
+    op.alter_column('role', 'description',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('resource', 'urn',
+               existing_type=sa.VARCHAR(length=100),
+               nullable=True)
+    op.alter_column('resource', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('resource', 'description',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('resource', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('permission', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('permission', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=True)
+    op.alter_column('permission', 'description',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('permission', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation_site_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation_site_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation_domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation_domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('invitation', 'organisation_id',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('invitation', 'last_name',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('invitation', 'invitor_id',
+               existing_type=postgresql.UUID(),
+               nullable=True)
+    op.alter_column('invitation', 'first_name',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('invitation', 'email',
+               existing_type=sa.VARCHAR(length=100),
+               nullable=True)
+    op.alter_column('invitation', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('domain_role', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('domain_role', 'grant_implicitly',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    op.alter_column('domain_role', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('domain', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('domain', 'name',
+               existing_type=sa.VARCHAR(length=30),
+               nullable=True)
+    op.alter_column('domain', 'description',
+               existing_type=sa.TEXT(),
+               nullable=True)
+    op.alter_column('domain', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    # ### end Alembic commands ###

--- a/access_control/models.py
+++ b/access_control/models.py
@@ -63,13 +63,14 @@ class GUID(TypeDecorator):
 class Domain(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
     parent_id = DB.Column(DB.Integer, DB.ForeignKey("domain.id"), nullable=True)
-    name = DB.Column(DB.VARCHAR(30), unique=True, index=True)
-    description = DB.Column(DB.Text)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    name = DB.Column(DB.VARCHAR(30), unique=True, index=True, nullable=False)
+    description = DB.Column(DB.Text, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -78,14 +79,15 @@ class Domain(DB.Model):
 
 class Role(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
-    label = DB.Column(DB.VARCHAR(30), unique=True, index=True)
-    description = DB.Column(DB.Text)
-    requires_2fa = DB.Column(DB.Boolean, default=True)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    label = DB.Column(DB.VARCHAR(30), unique=True, index=True, nullable=False)
+    description = DB.Column(DB.Text, nullable=False)
+    requires_2fa = DB.Column(DB.Boolean, default=True, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -94,13 +96,14 @@ class Role(DB.Model):
 
 class Permission(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
-    name = DB.Column(DB.VARCHAR(30), unique=True, index=True)
-    description = DB.Column(DB.Text)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    name = DB.Column(DB.VARCHAR(30), unique=True, index=True, nullable=False)
+    description = DB.Column(DB.Text, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -109,13 +112,14 @@ class Permission(DB.Model):
 
 class Resource(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
-    urn = DB.Column(DB.VARCHAR(100), unique=True, index=True)
-    description = DB.Column(DB.Text)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    urn = DB.Column(DB.VARCHAR(100), unique=True, index=True, nullable=False)
+    description = DB.Column(DB.Text, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -130,11 +134,12 @@ class RoleResourcePermission(DB.Model):
     permission_id = DB.Column(
         DB.Integer, DB.ForeignKey("permission.id"), primary_key=True
     )
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -145,16 +150,17 @@ class RoleResourcePermission(DB.Model):
 
 class Site(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
-    name = DB.Column(DB.VARCHAR(30), unique=True, index=True)
-    domain_id = DB.Column(DB.Integer, DB.ForeignKey("domain.id"), index=True)
-    description = DB.Column(DB.Text)
+    name = DB.Column(DB.VARCHAR(30), unique=True, index=True, nullable=False)
+    domain_id = DB.Column(DB.Integer, DB.ForeignKey("domain.id"), index=True, nullable=False)
+    description = DB.Column(DB.Text, nullable=False)
     client_id = DB.Column(DB.Integer, unique=True, index=True)
-    is_active = DB.Column(DB.Boolean, default=True)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    is_active = DB.Column(DB.Boolean, default=True, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -170,12 +176,13 @@ class DomainRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, DB.ForeignKey("role.id"), primary_key=True
     )
-    grant_implicitly = DB.Column(DB.Boolean, default=False)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    grant_implicitly = DB.Column(DB.Boolean, default=False, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -191,12 +198,13 @@ class SiteRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, DB.ForeignKey("role.id"), primary_key=True
     )
-    grant_implicitly = DB.Column(DB.Boolean, default=False)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    grant_implicitly = DB.Column(DB.Boolean, default=False, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -213,11 +221,12 @@ class UserSiteRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, primary_key=True
     )
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     __table_args__ = (
@@ -241,11 +250,12 @@ class UserDomainRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, primary_key=True
     )
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     __table_args__ = (
@@ -263,17 +273,18 @@ class UserDomainRole(DB.Model):
 
 class Invitation(DB.Model):
     id = DB.Column(GUID(), default=uuid.uuid1, primary_key=True)
-    first_name = DB.Column(DB.Text)
-    last_name = DB.Column(DB.Text)
-    email = DB.Column(DB.VARCHAR(100), unique=True, index=True)
+    first_name = DB.Column(DB.Text, nullable=False)
+    last_name = DB.Column(DB.Text, nullable=False)
+    email = DB.Column(DB.VARCHAR(100), unique=True, index=True, nullable=False)
     expires_at = DB.Column(DB.DateTime, nullable=False)
-    invitor_id = DB.Column(UUID)
-    organisation_id = DB.Column(DB.Integer)
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    invitor_id = DB.Column(UUID, nullable=False)
+    organisation_id = DB.Column(DB.Integer, nullable=False)
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     def __repr__(self):
@@ -290,11 +301,12 @@ class InvitationDomainRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, primary_key=True
     )
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     __table_args__ = (
@@ -318,11 +330,12 @@ class InvitationSiteRole(DB.Model):
     role_id = DB.Column(
         DB.Integer, primary_key=True
     )
-    created_at = DB.Column(DB.DateTime, default=utcnow())
+    created_at = DB.Column(DB.DateTime, default=utcnow(), nullable=False)
     updated_at = DB.Column(
         DB.DateTime,
         default=utcnow(),
-        onupdate=utcnow()
+        onupdate=utcnow(),
+        nullable=False
     )
 
     __table_args__ = (

--- a/access_control/test/test_methods.py
+++ b/access_control/test/test_methods.py
@@ -40,10 +40,10 @@ class ListFiltersTestCase(TestCase):
         except Exception:
             pass
         cls.domain_1, created = get_or_create(
-            models.Domain, name="Domain 1"
+            models.Domain, name="Domain 1", description="Test Domain"
         )
         cls.domain_2, created = get_or_create(
-            models.Domain, name="Domain 2", parent_id=cls.domain_1.id
+            models.Domain, name="Domain 2", description="Test Domain", parent_id=cls.domain_1.id
         )
 
     def test_list_entry(self):

--- a/access_control/test/test_methods.py
+++ b/access_control/test/test_methods.py
@@ -16,7 +16,7 @@ class GetOrCreateTestCase(TestCase):
             pass
 
         # Successfully create a new object
-        instance, created = get_or_create(models.Resource, urn=URN)
+        instance, created = get_or_create(models.Resource, urn=URN, description="Test")
         self.assertTrue(instance is not None)
         self.assertTrue(created)
 

--- a/swagger_server/test/controllers/test_invitation_controller.py
+++ b/swagger_server/test/controllers/test_invitation_controller.py
@@ -27,6 +27,12 @@ class InvitationTestCase(BaseTestCase):
     def setUp(self):
         models.InvitationDomainRole.query.delete()
         models.InvitationSiteRole.query.delete()
+        models.UserSiteRole.query.delete()
+        models.SiteRole.query.delete()
+        models.Site.query.delete()
+        models.UserDomainRole.query.delete()
+        models.DomainRole.query.delete()
+        models.Domain.query.delete()
         models.Invitation.query.delete()
         role_data = {
             "label": ("%s" % uuid.uuid4())[:30],


### PR DESCRIPTION
Same as the UDS migration.
The following table fields are now not nullable but are unique: 
`site`: `name`
`domain`: `name`
`permission`: `name`
`invitation`: `email`
`resource`: `urn`

These are populated with uuid values as random visible mistakes and can be corrected manually. 

The `domain_id` on sites are now also not nullable. All sites found without a domain_id are then given the top most domain found. If no top domain is found the next domain found with a parent_id is used. If in the rare event that there are sites and NO DOMAINS, a dud domain is created as a placeholder for the site `domain_id` values. This domain is heavily demarcated ask temporary and to be fixed and removed. 