### PR TITLE
Feature/geinfra 376

### DIFF
--- a/access_control/models.py
+++ b/access_control/models.py
@@ -153,7 +153,7 @@ class RoleResourcePermission(DB.Model):
 
 class Site(DB.Model):
     def __validate_deletion_method_data(self, lookup_id, data):
-        # Due to oddities in the orm level validation, this method is called
+        # Due to oddities in the ORM level validation, this method is called
         # twice. In __init__ to validate model creation and in an actual
         # validation method for updates.
         if lookup_id is not None and data is not None:

--- a/access_control/models.py
+++ b/access_control/models.py
@@ -4,7 +4,6 @@ import uuid
 
 from sqlalchemy import types
 from sqlalchemy.dialects.postgresql import UUID, CHAR
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import validates
 from sqlalchemy.sql import expression

--- a/access_control/models.py
+++ b/access_control/models.py
@@ -2,7 +2,6 @@ from urllib.parse import urlparse
 import jsonschema
 import uuid
 
-from flask import abort
 from sqlalchemy import types
 from sqlalchemy.dialects.postgresql import UUID, CHAR
 from sqlalchemy.orm.exc import NoResultFound
@@ -154,26 +153,22 @@ class RoleResourcePermission(DB.Model):
 
 
 class Site(DB.Model):
-
-    def __init__(self, *args, **kwargs):
-        # Due to the model being instantiated more than once with differing
-        # kwargs, it causes the validation decorator to sometimes only receive
-        # partial instance data.
-        if "deletion_method_data" in kwargs and "deletion_method_id" in kwargs:
-            try:
-                instance = DeletionMethod.query.filter_by(
-                    id=kwargs["deletion_method_id"]
-                ).one()
-            except NoResultFound:
-                abort(
-                    400,
-                    f"No result found for: DeletionMethod<id={self.deletion_method_id}>"
-                )
+    def __validate_deletion_method_data(self, lookup_id, data):
+        # Due to oddities in the orm level validation, this method is called
+        # twice. In __init__ to validate model creation and in an actual
+        # validation method for updates.
+        if lookup_id is not None and data is not None:
+            instance = DeletionMethod.query.filter_by(
+                id=lookup_id
+            ).one()
             jsonschema.validate(
-                kwargs["deletion_method_data"],
+                data,
                 schema=instance.data_schema,
                 format_checker=jsonschema.FormatChecker()
             )
+
+    def __init__(self, *args, **kwargs):
+        self.__validate_deletion_method_data(kwargs.get("deletion_method_id"), kwargs.get("deletion_method_data"))
         super().__init__(*args, **kwargs)
 
     id = DB.Column(DB.Integer, primary_key=True)
@@ -191,6 +186,11 @@ class Site(DB.Model):
         onupdate=utcnow(),
         nullable=False
     )
+
+    @validates("deletion_method_data")
+    def validate_deletion_method_data(self, key, data):
+        self.__validate_deletion_method_data(self.deletion_method_id, data)
+        return data
 
     def __repr__(self):
         return "<Site(%s-%s-%s-%s)>" % (

--- a/access_control/test/test_model_validation.py
+++ b/access_control/test/test_model_validation.py
@@ -2,9 +2,9 @@ from unittest import TestCase
 import jsonschema
 import uuid
 
-from ge_core_shared.db_actions import get_or_create, delete_entry, list_entry, crud
+from ge_core_shared.db_actions import crud
 
-from access_control import models, fixtures
+from access_control import models
 from access_control.fixtures.deletionmethods import DELETION_METHODS
 from project.app import DB as db
 from swagger_server.models.domain import Domain  # noqa: E501
@@ -58,8 +58,8 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9994,
             "is_active": True,
         }
-        with self.assertRaises(jsonschema.exceptions.ValidationError) as e:
-            site_model = crud(
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            crud(
                 model="Site",
                 api_model=Site,
                 data=site_data,
@@ -74,7 +74,7 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9995,
             "is_active": True,
         }
-        site_model = crud(
+        crud(
             model="Site",
             api_model=SiteCreate,
             data=site_data,
@@ -92,8 +92,8 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9996,
             "is_active": True,
         }
-        with self.assertRaises(jsonschema.exceptions.ValidationError) as e:
-            site_model = crud(
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            crud(
                 model="Site",
                 api_model=Site,
                 data=site_data,
@@ -108,7 +108,7 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9994,
             "is_active": True,
         }
-        site_model = crud(
+        crud(
             model="Site",
             api_model=SiteCreate,
             data=site_data,
@@ -128,7 +128,7 @@ class SiteModelValidationTestCase(TestCase):
             "is_active": True,
         }
         with self.assertRaises(jsonschema.exceptions.ValidationError) as e:
-            site_model = crud(
+            crud(
                 model="Site",
                 api_model=Site,
                 data=site_data,
@@ -143,7 +143,7 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9997,
             "is_active": True,
         }
-        site_model = crud(
+        crud(
             model="Site",
             api_model=SiteCreate,
             data=site_data,
@@ -162,8 +162,8 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9998,
             "is_active": True,
         }
-        with self.assertRaises(jsonschema.exceptions.ValidationError) as e:
-            site_model = crud(
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            crud(
                 model="Site",
                 api_model=Site,
                 data=site_data,
@@ -178,7 +178,7 @@ class SiteModelValidationTestCase(TestCase):
             "client_id": 9999,
             "is_active": True,
         }
-        site_model = crud(
+        crud(
             model="Site",
             api_model=SiteCreate,
             data=site_data,

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -6,15 +6,16 @@ from flask_sqlalchemy import SQLAlchemy
 from raven import Client
 from raven.contrib.flask import Sentry
 
+from ge_core_shared import decorators, exception_handlers, middleware
 from project import settings
 from project.errors import errors
-from sqlalchemy.exc import SQLAlchemyError
-from ge_core_shared import decorators, exception_handlers, middleware
 from prometheus_client import make_wsgi_app
+from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.wsgi import DispatcherMiddleware
 
 from swagger_server import encoder
 from swagger_server.controllers import access_control_controller, operational_controller
+from swagger_server.controllers import controller_validators
 
 DB = SQLAlchemy()
 
@@ -31,6 +32,9 @@ app.app.config["SQLALCHEMY_DATABASE_URI"] = settings.SQLALCHEMY_DATABASE_URI
 app.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = settings.SQLALCHEMY_TRACK_MODIFICATIONS
 
 app.add_error_handler(SQLAlchemyError, exception_handlers.db_exceptions)
+app.add_error_handler(
+    controller_validators.InvalidRequest, controller_validators.handle_invalid_request
+)
 app.app.register_blueprint(errors)
 
 # Register middleware

--- a/swagger_server/controllers/access_control_controller.py
+++ b/swagger_server/controllers/access_control_controller.py
@@ -3,7 +3,7 @@ import connexion
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from flask import abort, jsonify, current_app
+from flask import abort, jsonify
 from ge_core_shared import db_actions, decorators
 from project import settings
 from sqlalchemy import func, text
@@ -12,7 +12,6 @@ import project.app
 from access_control import models
 from swagger_server.controllers.operational_controller import get_all_user_roles
 from swagger_server.controllers.controller_validators import SiteValidator
-from swagger_server.models.all_user_roles import AllUserRoles  # noqa: E501
 from swagger_server.models.credentials import Credentials
 from swagger_server.models.deletion_method import DeletionMethod  # noqa: E501
 from swagger_server.models.domain import Domain  # noqa: E501
@@ -204,6 +203,7 @@ def credentials_update(credentials_id, data=None):  # noqa: E501
         query={"id": credentials_id},
     )
 
+
 def deletionmethod_create(data=None):  # noqa: E501
     """deletionmethod_create
 
@@ -284,6 +284,7 @@ def deletionmethod_read(deletionmethod_id):  # noqa: E501
         action="read",
         query={"id": deletionmethod_id}
     )
+
 
 def deletionmethod_update(deletionmethod_id, data=None):  # noqa: E501
     """deletionmethod_update
@@ -1455,6 +1456,7 @@ def roleresourcepermission_read(role_id, resource_id, permission_id):  # noqa: E
         }
     )
 
+
 def site_create(data=None):  # noqa: E501
     """site_create
 
@@ -1709,6 +1711,7 @@ def userdomainrole_create(data=None):  # noqa: E501
         data=data,
     )
 
+
 def userdomainrole_delete(user_id, domain_id, role_id):  # noqa: E501
     """userdomainrole_delete
 
@@ -1733,6 +1736,7 @@ def userdomainrole_delete(user_id, domain_id, role_id):  # noqa: E501
             "role_id": role_id,
         }
     )
+
 
 @decorators.list_response
 def userdomainrole_list(offset=None, limit=None, user_id=None, domain_id=None, role_id=None):  # noqa: E501
@@ -1768,6 +1772,7 @@ def userdomainrole_list(offset=None, limit=None, user_id=None, domain_id=None, r
             "order_by": ["user_id"]}
     )
 
+
 def userdomainrole_read(user_id, domain_id, role_id):  # noqa: E501
     """userdomainrole_read
 
@@ -1792,6 +1797,7 @@ def userdomainrole_read(user_id, domain_id, role_id):  # noqa: E501
             "role_id": role_id,
         }
     )
+
 
 def usersiterole_create(data=None):  # noqa: E501
     """usersiterole_create
@@ -1838,6 +1844,7 @@ def usersiterole_delete(user_id, site_id, role_id):  # noqa: E501
             "role_id": role_id,
         }
     )
+
 
 @decorators.list_response
 def usersiterole_list(offset=None, limit=None, user_id=None, site_id=None, role_id=None):  # noqa: E501
@@ -1898,6 +1905,3 @@ def usersiterole_read(user_id, site_id, role_id):  # noqa: E501
             "role_id": role_id,
         }
     )
-
-
-

--- a/swagger_server/controllers/access_control_controller.py
+++ b/swagger_server/controllers/access_control_controller.py
@@ -3,7 +3,7 @@ import connexion
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from flask import abort, jsonify
+from flask import abort, jsonify, current_app
 from ge_core_shared import db_actions, decorators
 from project import settings
 from sqlalchemy import func, text
@@ -11,6 +11,7 @@ from sqlalchemy import func, text
 import project.app
 from access_control import models
 from swagger_server.controllers.operational_controller import get_all_user_roles
+from swagger_server.controllers.controller_validators import SiteValidator
 from swagger_server.models.all_user_roles import AllUserRoles  # noqa: E501
 from swagger_server.models.credentials import Credentials
 from swagger_server.models.deletion_method import DeletionMethod  # noqa: E501
@@ -1454,7 +1455,6 @@ def roleresourcepermission_read(role_id, resource_id, permission_id):  # noqa: E
         }
     )
 
-
 def site_create(data=None):  # noqa: E501
     """site_create
 
@@ -1468,6 +1468,7 @@ def site_create(data=None):  # noqa: E501
     if connexion.request.is_json:
         data = connexion.request.get_json()
 
+    SiteValidator().validate_site_create(data)
     return db_actions.crud(
         model="Site",
         api_model=Site,
@@ -1552,6 +1553,7 @@ def site_update(site_id, data=None):  # noqa: E501
     """
     if connexion.request.is_json:
         data = connexion.request.get_json()
+    SiteValidator().validate_site_update(site_id, data)
 
     return db_actions.crud(
         model="Site",

--- a/swagger_server/controllers/controller_validators.py
+++ b/swagger_server/controllers/controller_validators.py
@@ -1,0 +1,82 @@
+import jsonschema
+from flask import jsonify
+from sqlalchemy.orm.exc import NoResultFound
+
+from access_control.models import (DeletionMethod, Site)
+
+
+# Exceptions and handlers
+class InvalidRequest(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = self.message
+        return rv
+
+
+def handle_invalid_request(error):
+    # Can be reused for most Exceptions
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
+# Validators
+class SiteValidator:
+
+    def validate_site_deletion_method_data(self, lookup_id, data):
+        try:
+            deletion_method = DeletionMethod.query.filter_by(
+                id=lookup_id
+            ).one()
+        except NoResultFound:
+            raise InvalidRequest(f"No result found for: DeletionMethod<id={lookup_id}>")
+        try:
+            jsonschema.validate(
+                data,
+                schema=deletion_method.data_schema,
+                format_checker=jsonschema.FormatChecker()
+            )
+        except jsonschema.ValidationError:
+            raise InvalidRequest(
+                f"deletion_method_data validation failed against schema: {deletion_method.data_schema}"
+            )
+
+    def validate_site_deletion_method_required_fields(self, lookup_id, data):
+        has_data = data or data == {}
+        if has_data and not lookup_id >= 0:
+            raise InvalidRequest("deletion_method_id is required if deletion_method_data is provided")
+        elif lookup_id >= 0 and not has_data:
+            raise InvalidRequest("deletion_method_data is required if deletion_method_id is provided")
+
+    def validate_site_create(self, data):
+        method_id = data.get("deletion_method_id")
+        method_data = data.get("deletion_method_data")
+        self.validate_site_deletion_method_required_fields(
+            method_id, method_data
+        )
+        self.validate_site_deletion_method_data(
+            method_id, method_data
+        )
+
+    def validate_site_update(self, lookup_id, data):
+        try:
+            site = Site.query.filter_by(id=lookup_id).one()
+        except NoResultFound:
+            raise InvalidRequest(f"No result found for: Site<id={lookup_id}>")
+        method_id = data.get("deletion_method_id") or site.deletion_method_id
+        method_data = data.get("deletion_method_data") or site.deletion_method_data
+        self.validate_site_deletion_method_required_fields(
+            method_id, method_data
+        )
+        self.validate_site_deletion_method_data(
+            method_id, method_data
+        )

--- a/swagger_server/test/__init__.py
+++ b/swagger_server/test/__init__.py
@@ -14,8 +14,9 @@ from flask_testing import TestCase
 from sqlalchemy.exc import SQLAlchemyError
 from ge_core_shared import decorators, exception_handlers, middleware
 
-from swagger_server.encoder import JSONEncoder
 from access_control import models
+from swagger_server.controllers import controller_validators
+from swagger_server.encoder import JSONEncoder
 
 
 DB = SQLAlchemy()
@@ -58,6 +59,10 @@ class BaseTestCase(TestCase):
         flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
         DB.init_app(flask_app)
         app.add_error_handler(SQLAlchemyError, exception_handlers.db_exceptions)
+        app.add_error_handler(
+            controller_validators.InvalidRequest,
+            controller_validators.handle_invalid_request
+        )
 
         # Register middleware
         middleware.auth_middleware(flask_app, "core_access_control")

--- a/swagger_server/test/controllers/test_site_controller.py
+++ b/swagger_server/test/controllers/test_site_controller.py
@@ -233,5 +233,5 @@ class SiteTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         r_data = json.loads(response.data)
         self.assertEqual(
-            r_data["message"], "deletion_method_data validation failed against schema: {'type': 'object', 'additionalProperties': False, 'properties': {}}"
+            r_data["message"], "The deletion method data does not conform to the schema defined for the deletion method none"
         )


### PR DESCRIPTION
Updates to site deletion_method data and id validation.

Update to site model to handle create AND update, but raises normal python exceptions.

Added validator that get used in the controllers themselves.
Added a custom exception and handler, registered to the connexion app in `swagger_server/test/__init__.py` and `swagger_server/__main__.py`

Flake8 cleanup of `access_control/test/test_model_validation.py`